### PR TITLE
fix : API 도메인 재설정

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,7 +1,7 @@
-# HTTP 서버
+# HTTP 서버 - API 서브도메인
 server {
     listen 80;
-    server_name ttobaki.app www.ttobaki.app;
+    server_name api.ttobaki.app;
 
     # Certbot 인증용
     location /.well-known/acme-challenge/ {
@@ -14,14 +14,20 @@ server {
     }
 }
 
-# HTTPS 서버
+# HTTPS 서버 - API 서브도메인
 server {
-    listen 443 ssl http2;
-    server_name ttobaki.app www.ttobaki.app;
+    listen 443 ssl;
+    http2 on;
+    server_name api.ttobaki.app;
 
-    # Certbot으로 발급받은 인증서
-    ssl_certificate /etc/letsencrypt/live/ttobaki.app/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/ttobaki.app/privkey.pem;
+    # Certbot으로 발급받은 인증서 (서브도메인용으로 재발급 필요)
+    ssl_certificate /etc/letsencrypt/live/api.ttobaki.app/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.ttobaki.app/privkey.pem;
+
+    # SSL 설정
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
 
     location / {
         proxy_pass http://app:8080;
@@ -29,6 +35,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ server:
   port: 8080
 
 cors:
-  allowed-origins: http://localhost:3000
+  allowed-origins: http://localhost:3000, https://ttobaki.app
 
 logging:
   level:


### PR DESCRIPTION
## ✨ Issue Number
> close #44

## 📄 작업 내용 (주요 변경 사항)
- nginx 설정을 api.ttobaki.app 서브도메인으로 변경
- SSL 인증서 경로를 api.ttobaki.app용으로 업데이트
- SSL 프로토콜 및 암호화 설정 추가
- CORS 설정에 프론트엔드 도메인 추가

## 🗂️ 파일 변경

## 💬 리뷰 요구사항


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
