### PR TITLE
feat: 음성 파일 크기 10mb로 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
       fail-on-empty-beans: false
     time-zone: Asia/Seoul
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+      enabled: true
+
 server:
   base-uri: ${SERVER_URI}
   port: 8080


### PR DESCRIPTION
## ✨ Issue Number
> close #57 

## 📄 작업 내용 (주요 변경 사항)
조음 키트 진단 평가 API 에 request로 받는 음성파일의 크기를 10mb로 설정하였습니다.
아무 설정도 안 하면 spring boot 기본 설정인 1mb로 설정되어있었습니다.

## 🗂️ 파일 변경
application.yml

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
