### PR TITLE
dev to main

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
       fail-on-empty-beans: false
     time-zone: Asia/Seoul
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+      enabled: true
+
 server:
   base-uri: ${SERVER_URI}
   port: 8080


### PR DESCRIPTION
## 📄 작업 내용 (주요 변경 사항)
조음키트 진단 평가 API에서 음성파일 전달 시 최대 10MB로 명시적 제한