### PR TITLE
feat: Swagger 기본 서버 URL을 https로 설정

### DIFF
--- a/src/main/java/com/example/GoSonGim_BE/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/GoSonGim_BE/global/config/SwaggerConfig.java
@@ -30,7 +30,8 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(apiInfo())
                 .addSecurityItem(securityRequirement)
-                .components(components);
+                .components(components)
+                .servers(List.of(new Server().url("https://api.ttobaki.app").description("Production Server")));
     }
 
     private Info apiInfo() {


### PR DESCRIPTION


## ✨ Issue Number
> close #63 

## 📄 작업 내용 (주요 변경 사항)
- Swagger 기본 서버 URL을 https로 설정
- Swagger UI에서 모든 API 요청이 `https://api.ttobaki.app`으로 전송되도록 변경
- 환경 변수와 무관하게 항상 https URL 사용 (하드코딩된 기본값)

## 🗂️ 파일 변경

### 신규 파일
```
```
### 수정 파일
```
src/main/java/com/example/GoSonGim_BE/global/config/SwaggerConfig.java
```

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
