### PR TITLE
feat: 연속학습일 조회 API

### DIFF
--- a/src/main/java/com/example/GoSonGim_BE/domain/kit/service/impl/KitServiceImpl.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/kit/service/impl/KitServiceImpl.java
@@ -152,7 +152,10 @@ public class KitServiceImpl implements KitService {
                         .build();
                     
                     kitStageLogRepository.save(log);
-                    
+
+                    // 연속 학습일 업데이트
+                    userService.updateUserStreak(userId);
+
                     // 학습 성공 시 레벨 업데이트
                     if (isSuccess) {
                         userService.updateUserLevel(userId);
@@ -269,13 +272,16 @@ public class KitServiceImpl implements KitService {
             .build();
 
         kitStageLogRepository.save(log);
-        
+
+        // 연속 학습일 업데이트
+        userService.updateUserStreak(userId);
+
         // 학습 성공 시 레벨 업데이트
         if (request.isSuccess()) {
             userService.updateUserLevel(userId);
         }
     }
-    
+
     @Override
     public DiagnosticResponse diagnosePronunciation(MultipartFile audioFile, String targetText) {
         try (InputStream audioStream = audioFile.getInputStream()) {

--- a/src/main/java/com/example/GoSonGim_BE/domain/situation/service/SituationServiceImpl.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/situation/service/SituationServiceImpl.java
@@ -35,6 +35,7 @@ import com.example.GoSonGim_BE.domain.situation.repository.SituationRepository;
 import com.example.GoSonGim_BE.domain.users.entity.User;
 import com.example.GoSonGim_BE.domain.users.exception.UserExceptions;
 import com.example.GoSonGim_BE.domain.users.repository.UserRepository;
+import com.example.GoSonGim_BE.domain.users.service.UserService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -51,6 +52,7 @@ public class SituationServiceImpl implements SituationService {
     private final SessionStorage sessionStorage;
     private final SituationLogRepository situationLogRepository;
     private final UserRepository userRepository;
+    private final UserService userService;
     private final OpenAIService openAIService;
     private final PronunciationAssessmentService pronunciationAssessmentService;
     private final ObjectMapper objectMapper;
@@ -220,6 +222,9 @@ public class SituationServiceImpl implements SituationService {
                 .build();
             
             situationLogRepository.save(situationLog);
+
+            // 연속 학습일 업데이트
+            userService.updateUserStreak(userId);
         } else {
             nextQuestion = generateNextQuestion(situation, conversationHistory, nextTurnIndex);
             Map<String, Object> nextTurn = new HashMap<>();
@@ -370,7 +375,10 @@ public class SituationServiceImpl implements SituationService {
             .build();
         
         SituationLog savedLog = situationLogRepository.save(situationLog);
-        
+
+        // 연속 학습일 업데이트
+        userService.updateUserStreak(userId);
+
         SituationSession completedSession = SituationSession.builder()
             .sessionId(session.getSessionId())
             .userId(session.getUserId())

--- a/src/main/java/com/example/GoSonGim_BE/domain/users/controller/UserController.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/users/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.GoSonGim_BE.domain.users.controller;
 
 import com.example.GoSonGim_BE.domain.users.dto.request.NicknameChangeRequest;
+import com.example.GoSonGim_BE.domain.users.dto.response.ContinuousDaysResponse;
 import com.example.GoSonGim_BE.domain.users.dto.response.DailyWordsResponse;
 import com.example.GoSonGim_BE.domain.users.dto.response.NicknameChangeResponse;
 import com.example.GoSonGim_BE.domain.users.dto.response.UserProfileResponse;
@@ -67,5 +68,13 @@ public class UserController {
         Long userId = (Long) authentication.getPrincipal();
         UserWithdrawalResponse response = userService.withdrawUser(userId);
         return ResponseEntity.ok(ApiResult.success(200, "탈퇴가 접수되었습니다. 30일 후 계정과 데이터가 영구 삭제됩니다.", response));
+    }
+
+    @Operation(summary = "연속 학습일 조회")
+    @GetMapping("/streak-days")
+    public ResponseEntity<ApiResult<ContinuousDaysResponse>> getContinuousDays(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        ContinuousDaysResponse response = userService.getContinuousDays(userId);
+        return ResponseEntity.ok(ApiResult.success(200, "연속 학습일 조회에 성공하였습니다.", response));
     }
 }

--- a/src/main/java/com/example/GoSonGim_BE/domain/users/dto/response/ContinuousDaysResponse.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/users/dto/response/ContinuousDaysResponse.java
@@ -1,0 +1,13 @@
+package com.example.GoSonGim_BE.domain.users.dto.response;
+
+/**
+ * 연속 학습일 조회 응답
+ */
+public record ContinuousDaysResponse(
+    int streakDays,         // 연속 학습일
+    boolean learnedToday    // 오늘 학습 여부
+) {
+    public static ContinuousDaysResponse of(int streakDays, boolean learnedToday) {
+        return new ContinuousDaysResponse(streakDays, learnedToday);
+    }
+}

--- a/src/main/java/com/example/GoSonGim_BE/domain/users/entity/User.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/users/entity/User.java
@@ -165,9 +165,30 @@ public class User extends BaseEntity {
     }
     
     /**
+     * 연속 학습일 업데이트
+     * 학습 완료 시 호출하여 streak 갱신
+     *
+     * @param activityDate 학습 활동 일자
+     */
+    public void updateStreak(LocalDate activityDate) {
+        if (this.lastActivityDate == null) {
+            this.streakDays = 1;
+        } else if (activityDate.equals(this.lastActivityDate)) {
+            // 같은 날 중복 학습 - 변경 없음
+            return;
+        } else if (activityDate.equals(this.lastActivityDate.plusDays(1))) {
+            this.streakDays++;
+        } else {
+            // 연속 끊김
+            this.streakDays = 1;
+        }
+        this.lastActivityDate = activityDate;
+    }
+
+    /**
      * 레벨 계산 및 업데이트
      * 성공한 고유 키트 2개당 1레벨 업
-     * 
+     *
      * @param uniqueSuccessfulKits 성공한 고유 키트 수
      */
     public void calculateAndUpdateLevel(long uniqueSuccessfulKits) {

--- a/src/main/java/com/example/GoSonGim_BE/domain/users/service/UserService.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/users/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.GoSonGim_BE.domain.users.service;
 
+import com.example.GoSonGim_BE.domain.users.dto.response.ContinuousDaysResponse;
 import com.example.GoSonGim_BE.domain.users.dto.response.DailyWordsResponse;
 import com.example.GoSonGim_BE.domain.users.dto.response.NicknameChangeResponse;
 import com.example.GoSonGim_BE.domain.users.dto.response.UserProfileResponse;
@@ -37,6 +38,11 @@ public interface UserService {
      * 사용자 레벨 업데이트
      */
     void updateUserLevel(Long userId);
+
+    /**
+     * 연속 학습일 업데이트
+     */
+    void updateUserStreak(Long userId);
     
     /**
      * 사용자 학습 통계 조회
@@ -47,4 +53,12 @@ public interface UserService {
      * 일별 학습 단어 목록 조회
      */
     DailyWordsResponse getDailyWords(Long userId, int page, int size);
+
+    /**
+     * 연속 학습일 조회
+     * - 어제 기준 연속 학습일 계산
+     * - 오늘 학습 시 오늘 포함
+     * - 어제 기준 연속 끊기면 0으로 계산
+     */
+    ContinuousDaysResponse getContinuousDays(Long userId);
 }


### PR DESCRIPTION
## ✨ Issue Number
> close #68 

## 📄 작업 내용 (주요 변경 사항)
- 어제 기준 연속 학습일 계산 (오늘 학습 시 오늘 포함)
- 어제 기준 연속 끊기면 0을 반환합니다.
- 오늘 학습했는지 여부를 true, false로 반환하고 오늘 학습했다면 오늘을 포함해서 계산합니다.
- 연속 학습일 계산은 조음 키트 또는 상황극을 진행하고 저장이 되었을 때 계산이 됩니다.

## 🗂️ 파일 변경

### 신규 파일
```
src/main/java/com/example/GoSonGim_BE/domain/users/dto/response/
  └── ContinuousDaysResponse.java
```
### 수정 파일
```
src/main/java/com/example/GoSonGim_BE/domain/
  ├── users/
  │   ├── entity/
  │   │   └── User.java
  │   ├── service/
  │   │   ├── UserService.java
  │   │   └── UserServiceImpl.java
  │   └── controller/
  │       └── UserController.java
  ├── kit/
  │   └── service/impl/
  │       └── KitServiceImpl.java
  └── situation/
      ├── service/
      │   └── SituationServiceImpl.java
      └── repository/
          └── SituationLogRepository.java
```

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
