### PR TITLE
fix: Docker Compose에서 외부 Redis 사용하도록 변경

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,29 +8,15 @@ services:
     env_file:
       - .env
     environment:
-      REDIS_HOST: redis  # Docker 네트워크 내부 서비스명 사용
-      REDIS_PORT: 6379
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}  # 비밀번호가 없으면 빈 문자열
+      REDIS_HOST: ${REDIS_HOST:-172.31.35.174}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
     ports:
       - "8080:8080"
-    depends_on:
-      - redis
     networks:
       - gosongim-network
     restart: unless-stopped
 
-  # Redis 서버
-  redis:
-    image: redis:7-alpine
-    container_name: gosongim-redis
-    ports:
-      - "6379:6379"
-    networks:
-      - gosongim-network
-    command: redis-server --appendonly yes  # 데이터 영속성
-    restart: unless-stopped
-    volumes:
-      - redis-data:/data
 
   # Nginx
   nginx:


### PR DESCRIPTION
## ✨ Issue Number
> close #71 

## 📄 작업 내용 (주요 변경 사항)
Docker Compose에서 Redis 서비스를 제거하고 서버에 설치된 외부 Redis를 사용하도록 변경했습니다.
- Docker 재시작 시 Redis 데이터 유실 문제
- RedisReadOnlyException 발생 문제
- 서버 Redis 활용으로 안정성 향상

## 🗂️ 파일 변경
- `docker-compose.prod.yml`에서 Redis 서비스 주석 처리
- `depends_on: redis` 제거
- `REDIS_HOST` 기본값을 호스트 IP로 변경

### 신규 파일
```
```
### 수정 파일
```
```

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

