### PR TITLE
fix: 조음 키트 복습 API 정렬 순서를 createdAt 오름차순으로 변경

### DIFF
--- a/src/main/java/com/example/GoSonGim_BE/domain/kit/repository/KitStageLogRepository.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/kit/repository/KitStageLogRepository.java
@@ -194,7 +194,7 @@ public interface KitStageLogRepository extends JpaRepository<KitStageLog, Long> 
               AND ks.kit_id = :kitId
         ) ksl
         WHERE ksl.rn <= CASE WHEN :kitId IN (1, 2, 3) THEN 1 ELSE 3 END
-        ORDER BY ksl.created_at DESC
+        ORDER BY ksl.created_at ASC
         """, nativeQuery = true)
     List<KitStageLog> findAllByUserIdAndKitId(@Param("userId") Long userId,
                                                @Param("kitId") Long kitId);

--- a/src/main/java/com/example/GoSonGim_BE/domain/review/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/review/service/impl/ReviewServiceImpl.java
@@ -210,8 +210,9 @@ public class ReviewServiceImpl implements ReviewService {
             }
         }
 
-        // 각 로그를 응답 DTO로 변환
+        // 각 로그를 응답 DTO로 변환 (createdAt 오름차순 정렬)
         List<ReviewKitRecordItemResponse> records = sessionLogs.stream()
+            .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt()))
             .map(log -> {
                 String audioUrl = null;
                 if (log.getAudioFileKey() != null && !log.getAudioFileKey().isBlank()) {


### PR DESCRIPTION
## ✨ Issue Number
> close #95 

## 📄 작업 내용 (주요 변경 사항)
조음 키트 복습 상세 조회 API와 조음 키트 복습 로그 상세 조회 API의 정렬 순서를 createdAt 기준 오름차순으로 변경했습니다.
- \`KitStageLogRepository.java\`
   - \`findAllByUserIdAndKitId\` 쿼리의 ORDER BY를 \`createdAt ASC\`로 변경

- \`ReviewServiceImpl.java\`
   - \`getKitLogRecord\` 메서드에서 createdAt 기준 오름차순 정렬 적용

## 🗂️ 파일 변경

### 신규 파일
```
```
### 수정 파일
```
- \`GET /api/v1/review/kits/{kitId}\` - 조음 키트 복습 상세 조회
- \`GET /api/v1/review/kits/logs/{recordingId}\` - 조음 키트 복습 로그 상세 조회 (일별 조회용)
```

## 💬 리뷰 요구사항

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
