### PR TITLE
fix: ios 호환가능하게 contentType, cacheControl 명시

### DIFF
--- a/src/main/java/com/example/GoSonGim_BE/domain/files/service/S3Service.java
+++ b/src/main/java/com/example/GoSonGim_BE/domain/files/service/S3Service.java
@@ -54,6 +54,7 @@ public class S3Service {
         PutObjectRequest objectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileKey)
+                .contentType("audio/wav")  // S3 메타데이터에 Content-Type 저장
                 .build();
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
@@ -65,11 +66,13 @@ public class S3Service {
         return presignedRequest.url();
     }
 
-    // 다운로드용 Presigned URL 생성
+    // 다운로드용 Presigned URL 생성 (iOS 호환)
     public URL generateDownloadPresignedUrl(String fileKey, int expirationMinutes) {
         GetObjectRequest objectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileKey)
+                .responseContentType("audio/wav")             // iOS에서 오디오로 인식
+                .responseCacheControl("public, max-age=3600") // iOS 스트리밍 안정화
                 .build();
 
         GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()


### PR DESCRIPTION
## ✨ Issue Number
> close #98 

## 📄 작업 내용 (주요 변경 사항)
- iOS Chrome 음성 파일 재생 문제 해결
- iOS는 Content-Type 헤더 없이 WAV 파일을 오디오로 인식 못하여 Presigned URL responseContentType audio/wav 필수 설정 및 Presigned URL responseCacheControl 설정

## 🗂️ 파일 변경

### 신규 파일
```
```
### 수정 파일
```
```

## 💬 리뷰 요구사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
